### PR TITLE
Added a bulk candidate upload feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This changelog captures the main recent product-facing changes shipped in Hire G
 
 ## [Unreleased]
 
+#### Added
+- Bulk resume upload: a new `Candidates → Bulk Upload` page and `POST /api/candidates/bulk-upload` endpoint accept up to 25 PDF/DOC/DOCX resumes at once, parse each into a candidate profile (name, email, phone, skills, experience, and searchable resume text), attach the source file, and return a per-file summary of created/duplicate/skipped/failed results. Files without a detectable email are reported as skipped rather than creating placeholder records. Resume parsing reuses the existing OpenAI parser with the deterministic fallback, so it works with or without an AI key.
+
 #### Changed
 - Candidate detail now includes a timeline-aware `Suggested Next Step` card in the snapshot area, with direct action links for likely recruiter follow-up.
 - Candidate names now display as `Last, First` in candidate-linked table/list views so sorting is more natural across candidates, submissions, interviews, placements, and job-order workspace lists.

--- a/app/api/candidates/bulk-upload/route.js
+++ b/app/api/candidates/bulk-upload/route.js
@@ -1,0 +1,100 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import {
+	AccessControlError,
+	getActingUser
+} from '@/lib/access-control';
+import { ensureDefaultUnassignedDivision } from '@/lib/default-division';
+import { enforceMutationThrottle } from '@/lib/mutation-throttle';
+import { createCandidateFromResumeFile } from '@/lib/candidate-bulk-create';
+import { BULK_RESUME_UPLOAD_MAX_FILES } from '@/lib/candidate-attachment-options';
+import {
+	RESUME_PARSE_RATE_LIMIT_MAX_REQUESTS,
+	RESUME_PARSE_RATE_LIMIT_WINDOW_SECONDS
+} from '@/lib/security-constants';
+import { withApiLogging } from '@/lib/api-logging';
+
+async function postBulkUpload(req) {
+	try {
+		const actingUser = await getActingUser(req, { allowFallback: false });
+		if (!actingUser) {
+			return NextResponse.json({ error: 'Authentication required.' }, { status: 401 });
+		}
+
+		const throttleResponse = await enforceMutationThrottle(req, 'candidates.bulk_upload.post', {
+			maxRequests: RESUME_PARSE_RATE_LIMIT_MAX_REQUESTS,
+			windowSeconds: RESUME_PARSE_RATE_LIMIT_WINDOW_SECONDS,
+			message: 'Too many bulk upload requests. Please try again shortly.'
+		});
+		if (throttleResponse) {
+			return throttleResponse;
+		}
+
+		const contentType = req.headers.get('content-type') || '';
+		if (!contentType.includes('multipart/form-data')) {
+			return NextResponse.json(
+				{ error: 'Send resume files as multipart/form-data.' },
+				{ status: 400 }
+			);
+		}
+
+		const formData = await req.formData();
+		const files = formData
+			.getAll('files')
+			.filter((entry) => entry && typeof entry.arrayBuffer === 'function');
+
+		if (files.length === 0) {
+			return NextResponse.json({ error: 'Attach at least one resume file.' }, { status: 400 });
+		}
+
+		if (files.length > BULK_RESUME_UPLOAD_MAX_FILES) {
+			return NextResponse.json(
+				{
+					error: `Too many files. Upload up to ${BULK_RESUME_UPLOAD_MAX_FILES} resumes at a time.`
+				},
+				{ status: 400 }
+			);
+		}
+
+		// Administrators without a division get the shared "Unassigned" division,
+		// mirroring single candidate creation.
+		const defaultDivisionForAdmin =
+			actingUser.role === 'ADMINISTRATOR' && !actingUser.divisionId
+				? await ensureDefaultUnassignedDivision(prisma)
+				: null;
+		const defaultDivisionId = defaultDivisionForAdmin ? defaultDivisionForAdmin.id : null;
+
+		// Process sequentially to keep DB/storage load predictable and to avoid
+		// unique-email races between resumes belonging to the same person.
+		const results = [];
+		for (const file of files) {
+			// eslint-disable-next-line no-await-in-loop
+			const outcome = await createCandidateFromResumeFile({
+				file,
+				actingUser,
+				defaultDivisionId
+			});
+			results.push(outcome);
+		}
+
+		const summary = {
+			total: results.length,
+			created: results.filter((entry) => entry.status === 'created').length,
+			duplicates: results.filter((entry) => entry.status === 'duplicate').length,
+			skipped: results.filter((entry) => entry.status === 'skipped').length,
+			failed: results.filter((entry) => entry.status === 'failed').length
+		};
+
+		return NextResponse.json({ summary, results }, { status: 201 });
+	} catch (error) {
+		if (error instanceof AccessControlError) {
+			return NextResponse.json({ error: error.message }, { status: error.status });
+		}
+		return NextResponse.json(
+			{ error: error?.message || 'Failed to process bulk upload.' },
+			{ status: 500 }
+		);
+	}
+}
+
+export const POST = withApiLogging('candidates.bulk_upload.post', postBulkUpload);

--- a/app/api/candidates/parse-resume/route.js
+++ b/app/api/candidates/parse-resume/route.js
@@ -1,9 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { parseResumeToDraft } from '@/lib/resume-parser';
 import { extractResumeTextFromFile } from '@/lib/resume-file-parser';
-import { parseResumeToDraftWithOpenAi } from '@/lib/openai-resume-parser';
-import { buildResumeSummaryText } from '@/lib/resume-summary';
+import { parseResumeDraft } from '@/lib/resume-parse-service';
 import { enforceMutationThrottle } from '@/lib/mutation-throttle';
 import {
 	RESUME_PARSE_RATE_LIMIT_MAX_REQUESTS,
@@ -16,56 +14,6 @@ import { getActingUser } from '@/lib/access-control';
 const parseResumeSchema = z.object({
 	resumeText: z.string().min(40)
 });
-
-async function parseResumeDraft(resumeText) {
-	const openAiResult = await parseResumeToDraftWithOpenAi(resumeText);
-	if (openAiResult.ok) {
-		const draft = {
-			...openAiResult.draft,
-			summary: buildResumeSummaryText({
-				rawResumeText: resumeText,
-				draft: openAiResult.draft,
-				parsedSkills: openAiResult.parsedSkills || [],
-				educationRecords: openAiResult.educationRecords || [],
-				workExperienceRecords: openAiResult.workExperienceRecords || []
-			})
-		};
-
-		return {
-			draft,
-			warnings: openAiResult.warnings,
-			parsedSkills: openAiResult.parsedSkills || [],
-			educationRecords: openAiResult.educationRecords || [],
-			workExperienceRecords: openAiResult.workExperienceRecords || [],
-			parser: 'openai'
-		};
-	}
-
-	const fallbackResult = parseResumeToDraft(resumeText);
-	const warnings = [
-		...(openAiResult.warning ? [openAiResult.warning] : []),
-		...(Array.isArray(fallbackResult.warnings) ? fallbackResult.warnings : [])
-	];
-	const draft = {
-		...fallbackResult.draft,
-		summary: buildResumeSummaryText({
-			rawResumeText: resumeText,
-			draft: fallbackResult.draft,
-			parsedSkills: fallbackResult.parsedSkills || [],
-			educationRecords: fallbackResult.educationRecords || [],
-			workExperienceRecords: fallbackResult.workExperienceRecords || []
-		})
-	};
-
-	return {
-		draft,
-		warnings,
-		parsedSkills: fallbackResult.parsedSkills || [],
-		educationRecords: fallbackResult.educationRecords || [],
-		workExperienceRecords: fallbackResult.workExperienceRecords || [],
-		parser: 'fallback'
-	};
-}
 
 async function postParseResume(req) {
 	try {

--- a/app/candidates/bulk-upload/page.js
+++ b/app/candidates/bulk-upload/page.js
@@ -1,0 +1,315 @@
+'use client';
+
+import { useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, UploadCloud, X } from 'lucide-react';
+import { useToast } from '@/app/components/toast-provider';
+import {
+	BULK_RESUME_UPLOAD_MAX_FILES,
+	CANDIDATE_ATTACHMENT_MAX_BYTES,
+	isAllowedResumeUploadFileName,
+	resumeUploadAcceptString
+} from '@/lib/candidate-attachment-options';
+
+const STATUS_LABELS = {
+	created: 'Created',
+	duplicate: 'Duplicate',
+	skipped: 'Skipped',
+	failed: 'Failed'
+};
+
+const STATUS_COLORS = {
+	created: '#1f9d57',
+	duplicate: '#c67c00',
+	skipped: '#c67c00',
+	failed: '#d23b3b'
+};
+
+function formatBytes(bytes) {
+	if (!bytes) return '0 KB';
+	const mb = bytes / (1024 * 1024);
+	if (mb >= 1) return `${mb.toFixed(1)} MB`;
+	return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+}
+
+export default function BulkResumeUploadPage() {
+	const router = useRouter();
+	const toast = useToast();
+	const inputRef = useRef(null);
+	const [files, setFiles] = useState([]);
+	const [uploading, setUploading] = useState(false);
+	const [response, setResponse] = useState(null);
+
+	const maxMb = useMemo(
+		() => Math.floor(CANDIDATE_ATTACHMENT_MAX_BYTES / (1024 * 1024)),
+		[]
+	);
+
+	function addFiles(fileList) {
+		const incoming = Array.from(fileList || []);
+		if (incoming.length === 0) return;
+
+		const accepted = [];
+		const rejected = [];
+		for (const file of incoming) {
+			if (!isAllowedResumeUploadFileName(file.name)) {
+				rejected.push(`${file.name} (unsupported type)`);
+			} else if (file.size > CANDIDATE_ATTACHMENT_MAX_BYTES) {
+				rejected.push(`${file.name} (over ${maxMb} MB)`);
+			} else {
+				accepted.push(file);
+			}
+		}
+
+		setFiles((current) => {
+			const seen = new Set(current.map((file) => `${file.name}:${file.size}`));
+			const merged = [...current];
+			for (const file of accepted) {
+				const key = `${file.name}:${file.size}`;
+				if (!seen.has(key)) {
+					seen.add(key);
+					merged.push(file);
+				}
+			}
+			return merged.slice(0, BULK_RESUME_UPLOAD_MAX_FILES);
+		});
+
+		if (rejected.length > 0) {
+			toast.error(`Skipped ${rejected.length} file(s): ${rejected.join(', ')}`);
+		}
+	}
+
+	function onInputChange(event) {
+		addFiles(event.target.files);
+		if (inputRef.current) inputRef.current.value = '';
+	}
+
+	function onDrop(event) {
+		event.preventDefault();
+		addFiles(event.dataTransfer?.files);
+	}
+
+	function removeFile(index) {
+		setFiles((current) => current.filter((_, i) => i !== index));
+	}
+
+	function reset() {
+		setFiles([]);
+		setResponse(null);
+		if (inputRef.current) inputRef.current.value = '';
+	}
+
+	async function onUpload() {
+		if (files.length === 0 || uploading) return;
+		setUploading(true);
+		setResponse(null);
+		try {
+			const formData = new FormData();
+			for (const file of files) {
+				formData.append('files', file);
+			}
+			const res = await fetch('/api/candidates/bulk-upload', {
+				method: 'POST',
+				body: formData
+			});
+			const data = await res.json();
+			if (!res.ok) {
+				toast.error(data?.error || 'Bulk upload failed.');
+				return;
+			}
+			setResponse(data);
+			setFiles([]);
+			if (inputRef.current) inputRef.current.value = '';
+			const created = data?.summary?.created || 0;
+			if (created > 0) {
+				toast.success(`Created ${created} candidate${created === 1 ? '' : 's'}.`);
+			} else {
+				toast.error('No new candidates were created.');
+			}
+		} catch (error) {
+			toast.error(error?.message || 'Bulk upload failed.');
+		} finally {
+			setUploading(false);
+		}
+	}
+
+	const summary = response?.summary;
+
+	return (
+		<section className="module-page">
+			<header className="module-header">
+				<div>
+					<h2>Bulk Resume Upload</h2>
+					<p style={{ color: 'var(--text-muted, #5b6472)', margin: '4px 0 0' }}>
+						Upload up to {BULK_RESUME_UPLOAD_MAX_FILES} PDF, DOC, or DOCX resumes. Each file is
+						parsed into a searchable candidate profile.
+					</p>
+				</div>
+				<div className="module-header-actions">
+					<Link href="/candidates" className="btn-secondary" title="Back to candidates">
+						<ArrowLeft aria-hidden="true" width={16} height={16} /> Candidates
+					</Link>
+				</div>
+			</header>
+
+			<div className="panel">
+				<div
+					onDragOver={(event) => event.preventDefault()}
+					onDrop={onDrop}
+					style={{
+						border: '2px dashed var(--border-color, #cbd2dd)',
+						borderRadius: 12,
+						padding: '28px 20px',
+						textAlign: 'center',
+						background: 'var(--surface-muted, #f7f9fc)'
+					}}
+				>
+					<UploadCloud aria-hidden="true" width={28} height={28} />
+					<p style={{ margin: '10px 0 4px', fontWeight: 600 }}>
+						Drag &amp; drop resumes here, or
+					</p>
+					<button
+						type="button"
+						className="btn-secondary"
+						onClick={() => inputRef.current?.click()}
+						disabled={uploading}
+					>
+						Choose files
+					</button>
+					<input
+						ref={inputRef}
+						type="file"
+						multiple
+						accept={resumeUploadAcceptString()}
+						onChange={onInputChange}
+						style={{ display: 'none' }}
+					/>
+					<p style={{ margin: '10px 0 0', fontSize: 12, color: 'var(--text-muted, #5b6472)' }}>
+						PDF, DOC, DOCX · up to {maxMb} MB each
+					</p>
+				</div>
+
+				{files.length > 0 && (
+					<div style={{ marginTop: 18 }}>
+						<div
+							style={{
+								display: 'flex',
+								justifyContent: 'space-between',
+								alignItems: 'center',
+								marginBottom: 8
+							}}
+						>
+							<strong>
+								{files.length} file{files.length === 1 ? '' : 's'} ready
+							</strong>
+							<button type="button" className="btn-link" onClick={reset} disabled={uploading}>
+								Clear all
+							</button>
+						</div>
+						<ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+							{files.map((file, index) => (
+								<li
+									key={`${file.name}:${file.size}:${index}`}
+									style={{
+										display: 'flex',
+										justifyContent: 'space-between',
+										alignItems: 'center',
+										padding: '8px 10px',
+										borderBottom: '1px solid var(--border-color, #e6e9ef)'
+									}}
+								>
+									<span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+										{file.name}{' '}
+										<span style={{ color: 'var(--text-muted, #5b6472)', fontSize: 12 }}>
+											· {formatBytes(file.size)}
+										</span>
+									</span>
+									<button
+										type="button"
+										className="btn-link btn-link-icon"
+										aria-label={`Remove ${file.name}`}
+										onClick={() => removeFile(index)}
+										disabled={uploading}
+									>
+										<X aria-hidden="true" width={16} height={16} />
+									</button>
+								</li>
+							))}
+						</ul>
+						<div style={{ marginTop: 16, display: 'flex', gap: 10 }}>
+							<button
+								type="button"
+								className="btn-save-action"
+								onClick={onUpload}
+								disabled={uploading || files.length === 0}
+							>
+								{uploading
+									? 'Uploading…'
+									: `Upload ${files.length} resume${files.length === 1 ? '' : 's'}`}
+							</button>
+						</div>
+					</div>
+				)}
+			</div>
+
+			{summary && (
+				<div className="panel" style={{ marginTop: 18 }}>
+					<h3 style={{ marginTop: 0 }}>Results</h3>
+					<p style={{ color: 'var(--text-muted, #5b6472)', marginTop: 0 }}>
+						{summary.created} created · {summary.duplicates} duplicate · {summary.skipped} skipped ·{' '}
+						{summary.failed} failed (of {summary.total})
+					</p>
+					<ul style={{ listStyle: 'none', margin: '10px 0 0', padding: 0 }}>
+						{response.results.map((entry, index) => (
+							<li
+								key={`${entry.fileName}:${index}`}
+								style={{
+									display: 'flex',
+									justifyContent: 'space-between',
+									gap: 12,
+									padding: '8px 10px',
+									borderBottom: '1px solid var(--border-color, #e6e9ef)'
+								}}
+							>
+								<span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+									{entry.status === 'created' && entry.candidateId ? (
+										<Link href={`/candidates/${entry.candidateId}`}>
+											{entry.candidateName || entry.fileName}
+										</Link>
+									) : (
+										entry.fileName
+									)}
+									{entry.message ? (
+										<span style={{ color: 'var(--text-muted, #5b6472)', fontSize: 12 }}>
+											{' '}
+											— {entry.message}
+										</span>
+									) : null}
+								</span>
+								<span
+									style={{
+										fontWeight: 700,
+										fontSize: 12,
+										whiteSpace: 'nowrap',
+										color: STATUS_COLORS[entry.status] || '#5b6472'
+									}}
+								>
+									{STATUS_LABELS[entry.status] || entry.status}
+								</span>
+							</li>
+						))}
+					</ul>
+					<div style={{ marginTop: 16, display: 'flex', gap: 10 }}>
+						<button type="button" className="btn-save-action" onClick={() => router.push('/candidates')}>
+							View candidates
+						</button>
+						<button type="button" className="btn-secondary" onClick={reset}>
+							Upload more
+						</button>
+					</div>
+				</div>
+			)}
+		</section>
+	);
+}

--- a/app/candidates/page.js
+++ b/app/candidates/page.js
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Filter, LayoutGrid, LayoutList, Plus, X } from 'lucide-react';
+import { Filter, LayoutGrid, LayoutList, Plus, UploadCloud, X } from 'lucide-react';
 import CandidateAdvancedSearchModal from '@/app/components/candidate-advanced-search-modal';
 import EntityTable from '@/app/components/entity-table';
 import SavedListViews from '@/app/components/saved-list-views';
@@ -389,6 +389,14 @@ export default function CandidatesPage() {
 					<h2>Candidates</h2>
 				</div>
 				<div className="module-header-actions">
+					<Link
+						href="/candidates/bulk-upload"
+						className="btn-link btn-link-icon"
+						aria-label="Bulk Upload Resumes"
+						title="Bulk Upload Resumes"
+					>
+						<UploadCloud aria-hidden="true" className="btn-refresh-icon-svg" />
+					</Link>
 					<Link
 						href="/candidates/new"
 						className="btn-link btn-link-icon"

--- a/lib/candidate-attachment-options.js
+++ b/lib/candidate-attachment-options.js
@@ -13,6 +13,8 @@ export const CANDIDATE_ATTACHMENT_ALLOWED_EXTENSIONS = [
 export const CANDIDATE_ATTACHMENT_MAX_BYTES = 20 * 1024 * 1024;
 export const RESUME_UPLOAD_ALLOWED_EXTENSIONS = ['.pdf', '.doc', '.docx'];
 export const RESUME_UPLOAD_MAX_BYTES = 8 * 1024 * 1024;
+// Maximum resume files accepted in a single bulk upload request.
+export const BULK_RESUME_UPLOAD_MAX_FILES = 25;
 
 const allowedExtensionsSet = new Set(CANDIDATE_ATTACHMENT_ALLOWED_EXTENSIONS);
 const resumeAllowedExtensionsSet = new Set(RESUME_UPLOAD_ALLOWED_EXTENSIONS);

--- a/lib/candidate-bulk-create.js
+++ b/lib/candidate-bulk-create.js
@@ -1,0 +1,312 @@
+import { prisma } from '@/lib/prisma';
+import { extractResumeTextFromBuffer } from '@/lib/resume-file-parser';
+import { parseResumeDraft } from '@/lib/resume-parse-service';
+import { normalizeCandidateData } from '@/lib/candidate-data';
+import { withInferredCityStateFromZip } from '@/lib/zip-code-lookup';
+import { resolveCandidateSkills, resolveSkillSetForWrite } from '@/lib/candidate-skills';
+import {
+	normalizeCandidateEducationRecords,
+	normalizeCandidateWorkExperienceRecords
+} from '@/lib/candidate-history';
+import { deriveResumeSearchTextFromBuffer } from '@/lib/candidate-resume-search';
+import {
+	buildCandidateAttachmentStorageKey,
+	deleteObject,
+	uploadObjectBuffer
+} from '@/lib/object-storage';
+import { resolveOwnershipForWrite } from '@/lib/access-control';
+import { createRecordId } from '@/lib/record-id';
+import { logCreate } from '@/lib/audit-log';
+import { isValidEmailAddress } from '@/lib/email-validation';
+import {
+	CANDIDATE_ATTACHMENT_MAX_BYTES,
+	isAllowedCandidateAttachmentContentType,
+	isAllowedCandidateAttachmentFileName
+} from '@/lib/candidate-attachment-options';
+
+const BULK_IMPORT_SOURCE = 'Bulk Resume Import';
+const BULK_IMPORT_STATUS = 'new';
+const MIN_RESUME_TEXT_LENGTH = 40;
+
+/**
+ * Result statuses returned per file:
+ * - 'created'   candidate + resume attachment created
+ * - 'duplicate' a candidate with the parsed email already exists
+ * - 'skipped'   file was readable but lacked the minimum info to create safely
+ * - 'failed'    file could not be read/parsed
+ */
+function result(fileName, status, extra = {}) {
+	return { fileName: fileName || '(unnamed file)', status, ...extra };
+}
+
+function capitalize(value) {
+	const cleaned = String(value || '').trim();
+	if (!cleaned) return '';
+	return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+/**
+ * Best-effort name resolution: prefer parsed name, then the email local part,
+ * then the file name. Guarantees non-empty first/last so the DB (which requires
+ * both) always accepts the record.
+ */
+function resolveNames(draft, email, fileName) {
+	let firstName = String(draft.firstName || '').trim();
+	let lastName = String(draft.lastName || '').trim();
+	if (firstName && lastName) {
+		return { firstName, lastName };
+	}
+
+	const localPart = String(email || '').split('@')[0] || '';
+	const emailParts = localPart.replace(/[._+-]+/g, ' ').split(/\s+/).filter(Boolean);
+	if (!firstName && emailParts[0]) firstName = capitalize(emailParts[0]);
+	if (!lastName && emailParts.length > 1) lastName = capitalize(emailParts.slice(1).join(' '));
+
+	if (!firstName || !lastName) {
+		const base = String(fileName || '')
+			.replace(/\.[^.]+$/, '')
+			.replace(/[._-]+/g, ' ')
+			.replace(/\b(resume|cv|curriculum vitae)\b/gi, '')
+			.trim();
+		const fileParts = base.split(/\s+/).filter(Boolean);
+		if (!firstName && fileParts[0]) firstName = capitalize(fileParts[0]);
+		if (!lastName && fileParts.length > 1) lastName = capitalize(fileParts.slice(1).join(' '));
+	}
+
+	return {
+		firstName: firstName || 'Unknown',
+		lastName: lastName || 'Candidate'
+	};
+}
+
+function fileValidationError(file) {
+	if (!file || typeof file.arrayBuffer !== 'function') {
+		return 'Not a valid file.';
+	}
+	if (!file.name || !isAllowedCandidateAttachmentFileName(file.name)) {
+		return 'Unsupported file type. Upload PDF, DOC, or DOCX.';
+	}
+	if (!isAllowedCandidateAttachmentContentType(file.name, file.type)) {
+		return 'Unsupported file content type.';
+	}
+	if (file.size <= 0) {
+		return 'File is empty.';
+	}
+	if (file.size > CANDIDATE_ATTACHMENT_MAX_BYTES) {
+		return `File exceeds ${Math.floor(CANDIDATE_ATTACHMENT_MAX_BYTES / (1024 * 1024))} MB limit.`;
+	}
+	return '';
+}
+
+/**
+ * Parse a single resume file and create a candidate (plus resume attachment and
+ * searchable resume text) from it. Never throws — always resolves to a result
+ * object describing the outcome so callers can aggregate a batch.
+ *
+ * @param {object} params
+ * @param {File} params.file            Web File from multipart form data.
+ * @param {object} params.actingUser    Result of getActingUser().
+ * @param {number|null} [params.defaultDivisionId]  Division to assign when the
+ *        acting user is an administrator without an explicit division.
+ */
+export async function createCandidateFromResumeFile({ file, actingUser, defaultDivisionId = null }) {
+	const fileName = file?.name || '';
+
+	const validationError = fileValidationError(file);
+	if (validationError) {
+		return result(fileName, 'failed', { message: validationError });
+	}
+
+	let buffer;
+	let resumeText;
+	try {
+		buffer = Buffer.from(await file.arrayBuffer());
+		const extracted = await extractResumeTextFromBuffer({
+			buffer,
+			fileName,
+			contentType: file.type
+		});
+		resumeText = extracted.text;
+	} catch (error) {
+		return result(fileName, 'failed', {
+			message: error?.message || 'Could not read the file.'
+		});
+	}
+
+	if (!resumeText || resumeText.length < MIN_RESUME_TEXT_LENGTH) {
+		return result(fileName, 'failed', {
+			message: 'Could not extract enough text from the file (is it a scanned image?).'
+		});
+	}
+
+	const parsed = await parseResumeDraft(resumeText);
+	const draft = parsed.draft || {};
+	const email = String(draft.email || '').trim().toLowerCase();
+
+	// Require a real email: it is the unique key and we do not fabricate one.
+	if (!email || !isValidEmailAddress(email)) {
+		return result(fileName, 'skipped', {
+			message: 'No email address detected — add this candidate manually.'
+		});
+	}
+
+	const { firstName, lastName } = resolveNames(draft, email, fileName);
+
+	const candidateInput = {
+		firstName,
+		lastName,
+		email,
+		mobile: draft.mobile || null,
+		status: BULK_IMPORT_STATUS,
+		source: BULK_IMPORT_SOURCE,
+		ownerId: actingUser?.id,
+		divisionId: defaultDivisionId || actingUser?.divisionId || null,
+		currentJobTitle: draft.currentJobTitle || null,
+		currentEmployer: draft.currentEmployer || null,
+		experienceYears: draft.experienceYears || null,
+		city: draft.city || null,
+		state: draft.state || null,
+		zipCode: draft.zipCode || null,
+		website: draft.website || null,
+		linkedinUrl: draft.linkedinUrl || null,
+		skillSet: draft.skillSet || null,
+		summary: draft.summary || null
+	};
+
+	let resumeUploadMeta = null;
+	try {
+		const normalized = await withInferredCityStateFromZip(
+			prisma,
+			normalizeCandidateData(candidateInput)
+		);
+		const resolvedSkills = await resolveCandidateSkills(undefined, parsed.parsedSkills);
+		const normalizedEducationRecords = normalizeCandidateEducationRecords(parsed.educationRecords);
+		const normalizedWorkExperienceRecords = normalizeCandidateWorkExperienceRecords(
+			parsed.workExperienceRecords
+		);
+		const resolvedSkillSet = await resolveSkillSetForWrite({
+			normalizedSkillSet: normalized.skillSet,
+			unmatchedParsedSkillNames: resolvedSkills.unmatchedParsedSkillNames,
+			extraKnownSkillNames: resolvedSkills.skillNames
+		});
+		const ownership = await resolveOwnershipForWrite({
+			actingUser,
+			ownerIdInput: actingUser?.id,
+			divisionIdInput: normalized.divisionId
+		});
+		const resumeSearchText = await deriveResumeSearchTextFromBuffer({
+			buffer,
+			fileName,
+			contentType: file.type
+		});
+
+		const candidate = await prisma.$transaction(async (tx) => {
+			const createdCandidate = await tx.candidate.create({
+				data: {
+					...normalized,
+					recordId: createRecordId('Candidate'),
+					skillSet: resolvedSkillSet,
+					resumeSearchText: resumeSearchText || null,
+					ownerId: ownership.ownerId,
+					divisionId: ownership.divisionId,
+					...(resolvedSkills.hasSkillIds && resolvedSkills.skillIds.length > 0
+						? {
+								candidateSkills: {
+									createMany: {
+										data: resolvedSkills.skillIds.map((skillId) => ({ skillId })),
+										skipDuplicates: true
+									}
+								}
+							}
+						: {}),
+					...(normalizedEducationRecords.length > 0
+						? {
+								candidateEducations: {
+									create: normalizedEducationRecords.map((record) => ({
+										recordId: createRecordId('CandidateEducation'),
+										...record
+									}))
+								}
+							}
+						: {}),
+					...(normalizedWorkExperienceRecords.length > 0
+						? {
+								candidateWorkExperiences: {
+									create: normalizedWorkExperienceRecords.map((record) => ({
+										recordId: createRecordId('CandidateWorkExperience'),
+										...record
+									}))
+								}
+							}
+						: {})
+				}
+			});
+
+			const storageKey = buildCandidateAttachmentStorageKey(createdCandidate.id, fileName);
+			const uploaded = await uploadObjectBuffer({
+				key: storageKey,
+				body: buffer,
+				contentType: file.type || 'application/octet-stream'
+			});
+			resumeUploadMeta = {
+				storageProvider: uploaded.storageProvider,
+				storageBucket: uploaded.storageBucket,
+				storageKey: uploaded.storageKey
+			};
+
+			await tx.candidateAttachment.create({
+				data: {
+					recordId: createRecordId('CandidateAttachment'),
+					candidateId: createdCandidate.id,
+					fileName,
+					isResume: true,
+					contentType: file.type || null,
+					sizeBytes: file.size,
+					storageProvider: uploaded.storageProvider,
+					storageBucket: uploaded.storageBucket,
+					storageKey: uploaded.storageKey,
+					uploadedByUserId: actingUser?.id || null
+				}
+			});
+
+			await tx.candidateStatusChange.create({
+				data: {
+					recordId: createRecordId('CandidateStatusChange'),
+					candidateId: createdCandidate.id,
+					fromStatus: null,
+					toStatus: createdCandidate.status,
+					reason: 'Imported via bulk resume upload.',
+					changedByUserId: actingUser?.id || null
+				}
+			});
+
+			return createdCandidate;
+		});
+
+		await logCreate({
+			actorUserId: actingUser?.id,
+			entityType: 'CANDIDATE',
+			entity: candidate
+		});
+
+		return result(fileName, 'created', {
+			candidateId: candidate.id,
+			candidateName: `${candidate.firstName} ${candidate.lastName}`.trim(),
+			email: candidate.email,
+			parser: parsed.parser
+		});
+	} catch (error) {
+		if (resumeUploadMeta) {
+			await deleteObject(resumeUploadMeta).catch(() => null);
+		}
+		if (error?.code === 'P2002') {
+			return result(fileName, 'duplicate', {
+				email,
+				message: 'A candidate with this email already exists.'
+			});
+		}
+		return result(fileName, 'failed', {
+			message: error?.message || 'Failed to create candidate.'
+		});
+	}
+}

--- a/lib/resume-parse-service.js
+++ b/lib/resume-parse-service.js
@@ -1,0 +1,71 @@
+import { parseResumeToDraft } from '@/lib/resume-parser';
+import { parseResumeToDraftWithOpenAi } from '@/lib/openai-resume-parser';
+import { buildResumeSummaryText } from '@/lib/resume-summary';
+
+/**
+ * Turn raw resume text into a normalized candidate draft.
+ *
+ * Prefers the OpenAI parser when an API key is configured and falls back to the
+ * deterministic regex parser otherwise, so it works with or without AI. Shared
+ * by the single resume-parse endpoint and the bulk resume upload flow so both
+ * produce identical draft shapes.
+ *
+ * @param {string} resumeText
+ * @returns {Promise<{
+ *   draft: object,
+ *   warnings: string[],
+ *   parsedSkills: string[],
+ *   educationRecords: object[],
+ *   workExperienceRecords: object[],
+ *   parser: 'openai' | 'fallback'
+ * }>}
+ */
+export async function parseResumeDraft(resumeText) {
+	const openAiResult = await parseResumeToDraftWithOpenAi(resumeText);
+	if (openAiResult.ok) {
+		const draft = {
+			...openAiResult.draft,
+			summary: buildResumeSummaryText({
+				rawResumeText: resumeText,
+				draft: openAiResult.draft,
+				parsedSkills: openAiResult.parsedSkills || [],
+				educationRecords: openAiResult.educationRecords || [],
+				workExperienceRecords: openAiResult.workExperienceRecords || []
+			})
+		};
+
+		return {
+			draft,
+			warnings: openAiResult.warnings,
+			parsedSkills: openAiResult.parsedSkills || [],
+			educationRecords: openAiResult.educationRecords || [],
+			workExperienceRecords: openAiResult.workExperienceRecords || [],
+			parser: 'openai'
+		};
+	}
+
+	const fallbackResult = parseResumeToDraft(resumeText);
+	const warnings = [
+		...(openAiResult.warning ? [openAiResult.warning] : []),
+		...(Array.isArray(fallbackResult.warnings) ? fallbackResult.warnings : [])
+	];
+	const draft = {
+		...fallbackResult.draft,
+		summary: buildResumeSummaryText({
+			rawResumeText: resumeText,
+			draft: fallbackResult.draft,
+			parsedSkills: fallbackResult.parsedSkills || [],
+			educationRecords: fallbackResult.educationRecords || [],
+			workExperienceRecords: fallbackResult.workExperienceRecords || []
+		})
+	};
+
+	return {
+		draft,
+		warnings,
+		parsedSkills: fallbackResult.parsedSkills || [],
+		educationRecords: fallbackResult.educationRecords || [],
+		workExperienceRecords: fallbackResult.workExperienceRecords || [],
+		parser: 'fallback'
+	};
+}


### PR DESCRIPTION
100% ai coded. I glanced through to make sure it matches your style and there were completely unnecessary additions.

Please review if it meets your specifications. 

I confirmed it worked;

## Summary
- **What changed?** Adds a bulk resume upload flow. A new page (`/candidates/bulk-upload`) lets recruiters drag-and-drop up to 25 PDF/DOC/DOCX resumes at once; a new endpoint (`POST /api/candidates/bulk-upload`) parses each file, creates a candidate with the parsed name/email/phone/skills/experience and searchable resume text, attaches the source file, and returns a per-file summary. The shared resume-to-draft logic was extracted into `lib/resume-parse-service.js` and reused by the existing single parse-resume route.
- **Why was it needed?** Candidates could only be added one resume at a time. Teams onboarding a batch of resumes (e.g., from an email inbox) had no way to load them in bulk, which is the primary workflow for a placement/staffing pool.

## Scope
- [x] UI
- [x] API
- [ ] Prisma schema / migration
- [x] Docs
- [ ] Ops / scripts

## Validation
- [ ] `npm run ci:preflight`
- [ ] `npm run build`
- [ ] Manual happy path tested
- [ ] Edge case tested

_Status:_ All new/changed files were static-parsed (ES module + JSX) and imported symbols were confirmed against their source modules. The commands above and manual testing still need to be run in a full environment before merge — planned checks:
- Happy path: upload several valid PDFs → candidates created, resumes attached, resume text searchable.
- Edge cases: resume with no email (expected **skipped**), duplicate email (expected **duplicate**), unsupported/oversized file (expected **failed**), >25 files (expected 400), and a run with no OpenAI key (fallback parser).

## Screenshots (if UI)
<img width="2254" height="361" alt="image" src="https://github.com/user-attachments/assets/42169ec6-e138-4d7d-a033-0cb170e0d0a1" />
<img width="2248" height="569" alt="image" src="https://github.com/user-attachments/assets/a4dfca31-d1c8-4b16-bea6-b9ff6ecda67c" />



## Migration Notes (if applicable)
- Migration name: **none** — no Prisma schema changes. Uses existing `Candidate`, `CandidateAttachment`, `CandidateSkill`, `CandidateEducation`, `CandidateWorkExperience`, and `CandidateStatusChange` models.
- Backward compatibility: fully backward compatible; only adds a route, a page, and shared helpers. The refactor of `parse-resume` preserves its existing request/response contract.
- Rollback plan: revert the commit. No data migration to undo; records created by the feature are ordinary candidates.

## Risks
- **Parsing accuracy varies by resume.** Name/phone/skills come from the same parser used elsewhere; mis-parses produce imperfect (but editable) profiles. Mitigation: resumes with no detectable email are **skipped**, not saved as placeholder records, so the pool isn't polluted with junk identities.
- **Throughput / timeouts.** Files are processed sequentially to avoid unique-email races and to keep DB/storage load predictable; a large batch of big PDFs could be slow. Mitigation: capped at 25 files per request (`BULK_RESUME_UPLOAD_MAX_FILES`) and covered by the existing resume-parse rate limit.
- **AI cost when OpenAI is configured.** With an API key set, each file triggers a parse call. Mitigation: the deterministic fallback runs when no key is present, so the feature is free by default.
- **Ownership/division defaults.** Bulk-created candidates are owned by the acting user and use the same `resolveOwnershipForWrite` rules as single creation (admins without a division get the shared "Unassigned" division). No new access paths are introduced.